### PR TITLE
Add Windows build script and server start command to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "main": "main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc && chmod 755 build/main.js"
+    "build": "tsc && chmod 755 build/main.js",
+    "build:windows": "tsc",
+    "server": "node build/main.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Este PR adiciona algumas features ao `package.json` melhorando o build e a execução do servidor.

* Adicionado o script `build:windows` para o build no Windows (O tcs é suficiente para o build no SO e o chmod dá erro mesmo com WSL bem configurado na máquina).
* Adicionado o script `server` para iniciar o servidor (Garantindo um padrão de scripts do repositório).